### PR TITLE
Extract lib, write integration tests

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
 DATABASE_URL=postgres://localhost/website_development
+DATABASE_URL_TEST=postgres://localhost/website_test
 MESSAGE_AUTHOR_0_ID=a0
 MESSAGE_AUTHOR_1_ID=a1
 MESSAGE_GROUP_ID=dev-message

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1792,7 +1792,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "web"
+name = "web-server"
 version = "0.1.0"
 dependencies = [
  "actix-files 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "web"
+name = "web-server"
 version = "0.1.0"
 authors = ["Stephen Karger"]
 edition = "2018"

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-web: ./target/release/web
+web: ./target/release/web_server
 release: ./target/release/diesel migration run
 

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-web: ./target/release/web_server
+web: ./target/release/web-server
 release: ./target/release/diesel migration run
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@ systemfd --no-pid -- cargo watch -x run
 To build CSS:
 `yarn build`
 
+## Testing
+
+To build the test DB:
+
+```
+createdb website_test
+```
+
+Migrate it:
+```
+DATABASE_URL=postgres://localhost/website_test diesel migration run
+```
+
 ## Deployment
 
 The backend server is hosted on [Heroku](https://www.heroku.com/).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,28 @@
+use actix_web::http::{StatusCode};
+use actix_web::{
+    web, HttpResponse, Result,
+};
+
+use handlebars::Handlebars;
+use serde_json::json;
+
+pub mod templates { pub mod registry; }
+
+pub struct AppState<'a> {
+    pub template_registry: Handlebars<'a>,
+}
+
+pub fn home(data: web::Data<AppState>) -> Result<HttpResponse> {
+    let context = json!({
+        "currentPage": "home",
+        "title": "Home",
+    });
+    Ok(HttpResponse::build(StatusCode::OK)
+        .content_type("text/html; charset=utf-8")
+        .body(data.template_registry.render("home", &context).unwrap()))
+
+}
+
+pub fn register_templates<'a>() -> Handlebars<'a> {
+    templates::registry::register_templates()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,8 @@
 extern crate diesel;
 
 use actix_files as fs;
-use actix_web::http::{StatusCode};
 use actix_web::{
-    web, HttpResponse, Result,
+    web, http::StatusCode, HttpResponse, Result,
 };
 
 use handlebars::Handlebars;
@@ -47,6 +46,10 @@ pub fn p404(data: web::Data<AppState>) -> Result<HttpResponse> {
 
 pub fn favicon() -> Result<fs::NamedFile> {
     Ok(fs::NamedFile::open("static/favicon.ico")?)
+}
+
+pub fn static_files() -> fs::Files {
+    fs::Files::new("/static", "static").show_files_listing()
 }
 
 pub fn home(data: web::Data<AppState>) -> Result<HttpResponse> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,12 +4,21 @@ use actix_web::{
 };
 
 use handlebars::Handlebars;
+use serde::Deserialize;
 use serde_json::json;
 
 pub mod templates { pub mod registry; }
 
 pub struct AppState<'a> {
     pub template_registry: Handlebars<'a>,
+}
+
+#[derive(Deserialize)]
+pub struct MessagePayload {
+    pub message_group: String,
+    pub index: i32,
+    pub body: String,
+    pub author: String,
 }
 
 pub fn home(data: web::Data<AppState>) -> Result<HttpResponse> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,12 @@ pub struct MessagePayload {
     pub author: String,
 }
 
+pub fn request_data<'a>() -> AppState<'a> {
+    AppState {
+        template_registry: register_templates(),
+    }
+}
+
 pub fn p404(data: web::Data<AppState>) -> Result<HttpResponse> {
     let context = json!({
         "currentPage": "404",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+#[macro_use]
+extern crate diesel;
+
+use actix_files as fs;
 use actix_web::http::{StatusCode};
 use actix_web::{
     web, HttpResponse, Result,
@@ -6,7 +10,11 @@ use actix_web::{
 use handlebars::Handlebars;
 use serde::Deserialize;
 use serde_json::json;
+use std::{env};
 
+pub mod db;
+pub mod models;
+pub mod schema;
 pub mod templates { pub mod registry; }
 
 pub struct AppState<'a> {
@@ -21,6 +29,20 @@ pub struct MessagePayload {
     pub author: String,
 }
 
+pub fn p404(data: web::Data<AppState>) -> Result<HttpResponse> {
+    let context = json!({
+        "currentPage": "404",
+        "title": "Not Found",
+    });
+    Ok(HttpResponse::build(StatusCode::NOT_FOUND)
+        .content_type("text/html; charset=utf-8")
+        .body(data.template_registry.render("404", &context).unwrap()))
+}
+
+pub fn favicon() -> Result<fs::NamedFile> {
+    Ok(fs::NamedFile::open("static/favicon.ico")?)
+}
+
 pub fn home(data: web::Data<AppState>) -> Result<HttpResponse> {
     let context = json!({
         "currentPage": "home",
@@ -32,6 +54,114 @@ pub fn home(data: web::Data<AppState>) -> Result<HttpResponse> {
 
 }
 
+pub fn about(data: web::Data<AppState>) -> Result<HttpResponse> {
+    let context = json!({
+        "currentPage": "about",
+        "title": "About",
+    });
+    Ok(HttpResponse::build(StatusCode::OK)
+        .content_type("text/html; charset=utf-8")
+        .body(data.template_registry.render("about", &context).unwrap()))
+}
+
 pub fn register_templates<'a>() -> Handlebars<'a> {
     templates::registry::register_templates()
+}
+
+pub fn create_message_in_group(data: web::Data<AppState>, path: web::Path<String>, mut message_payload: web::Json<MessagePayload>) -> Result<HttpResponse> {
+    let message_group = &format!("{}", path);
+    if !authorized(&message_group) {
+        p404(data)
+    } else {
+        message_payload.message_group = message_group.to_string();
+        let message_author_1 = env::var("MESSAGE_AUTHOR_1_ID")
+            .unwrap_or_else(|_| "".to_string());
+        message_payload.author = message_author_1;
+
+        let key = format!("message{}", message_payload.index);
+        let context = json!({
+            "currentPage": "messages",
+            "title": "Messages",
+            key: message_payload.body,
+        });
+
+        let connection = db::establish_connection();
+        db::create_message(&connection, &message_payload);
+
+        Ok(HttpResponse::build(StatusCode::CREATED)
+            .content_type("application/json; charset=utf-8")
+            .json(context))
+    }
+}
+
+pub fn load_message_group(data: web::Data<AppState>, path: web::Path<String>) -> Result<HttpResponse> {
+    let message_group = format!("{}", path);
+    if !authorized(&message_group) {
+        p404(data)
+    } else {
+        let connection = db::establish_connection();
+        let new_messages = db::message_bodies_for_group(&connection, &message_group);
+
+        let button_text_1 = button_text(&new_messages[1]);
+        let input_disabled_1 = input_disabled(&new_messages[1]);
+        let button_text_3 = button_text(&new_messages[3]);
+        let input_disabled_3 = input_disabled(&new_messages[3]);
+        let guidance_1 = guidance(&new_messages[1]);
+        let guidance_3 = guidance(&new_messages[3]);
+
+        let context = json!({
+            "currentPage": "messages",
+            "title": "Messages",
+            "author0": "a0",
+            "author1": "a1",
+            "message0": paragraphs(&new_messages[0]),
+            "message1": &new_messages[1],
+            "inputDisabled1": input_disabled_1,
+            "buttonText1": button_text_1,
+            "guidance1": guidance_1,
+            "message2": paragraphs(&new_messages[2]),
+            "inputDisabled3": input_disabled_3,
+            "buttonText3": button_text_3,
+            "guidance3": guidance_3,
+            "message3": &new_messages[3],
+            "messageGroup": message_group,
+        });
+
+        Ok(HttpResponse::build(StatusCode::OK)
+            .content_type("text/html; charset=utf-8")
+            .body(data.template_registry.render("messages", &context).unwrap()))
+    }
+}
+
+fn paragraphs(body: &str) -> String {
+    body.split("\n").map(|paragraph| format!("<p>{}</p>", paragraph)).collect::<Vec<String>>().join("")
+}
+
+fn button_text(body: &str) -> &str {
+    if body.len() > 0 {
+        "Edit"
+    } else {
+        "Save"
+    }
+}
+
+fn input_disabled(body: &str) -> &str {
+    if body.len() > 0 {
+        "disabled"
+    } else {
+        ""
+    }
+}
+
+fn guidance(body: &str) -> &str {
+    if body.len() > 0 {
+        ""
+    } else {
+        "You will be able to edit after saving."
+    }
+}
+
+fn authorized(message_group: &str) -> bool {
+    let allowed_message_group = env::var("MESSAGE_GROUP_ID").unwrap();
+    message_group == allowed_message_group
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use dotenv::dotenv;
 use listenfd::ListenFd;
 use std::{env, io};
 
-use web_server::{self, AppState};
+use web_server;
 
 fn main() -> io::Result<()> {
     dotenv().ok();
@@ -29,9 +29,7 @@ fn main() -> io::Result<()> {
 
     let mut server = HttpServer::new(move || {
         App::new()
-            .data(AppState {
-                template_registry: web_server::register_templates(),
-            })
+            .data(web_server::request_data())
             .wrap(middleware::Condition::new(redirect_to_https, RedirectHTTPS::default()))
             .wrap(middleware::Compress::default())
             .wrap(middleware::DefaultHeaders::new().header("Cache-Control", "max-age=0"))

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,8 +46,11 @@ fn register_templates() -> Result<Handlebars<'static>> {
             .and_then(|_| { template_registry.register_template_file("404", "./src/templates/404.hbs") })
             .and_then(|_| { template_registry.register_template_file("messages", "./src/templates/messages.hbs") })
             .and_then(|_| { template_registry.register_template_file("about", "./src/templates/about.hbs") });
-    if res.is_err() {
-        panic!("Could not register template")
+    match res {
+        Ok(_) => { },
+        Err(tfe) => {
+            panic!("Could not register template: {}", tfe)
+        }
     }
 
     Ok(template_registry)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,154 +1,17 @@
-#[macro_use]
-extern crate actix_web;
-#[macro_use]
-extern crate diesel;
-
 use actix_files as fs;
-use actix_web::http::{StatusCode};
 use actix_web::{
-    guard, middleware, web, App, HttpResponse, HttpServer, Result,
+    guard, middleware, web, App, HttpResponse, HttpServer
 };
-
+use actix_web_middleware_redirect_https::RedirectHTTPS;
 use dotenv::dotenv;
 use listenfd::ListenFd;
-use serde_json::json;
 use std::{env, io};
-use actix_web_middleware_redirect_https::RedirectHTTPS;
 
-pub mod schema;
-pub mod models;
-pub mod db;
-
-use self::db::{establish_connection, message_bodies_for_group, create_message};
-use web_server::{self, AppState, MessagePayload};
-
-fn create_message_in_group(data: web::Data<AppState>, path: web::Path<String>, mut message_payload: web::Json<MessagePayload>) -> Result<HttpResponse> {
-    let message_group = &format!("{}", path);
-    if !authorized(&message_group) {
-        p404(data)
-    } else {
-        message_payload.message_group = message_group.to_string();
-        let message_author_1 = env::var("MESSAGE_AUTHOR_1_ID")
-            .unwrap_or_else(|_| "".to_string());
-        message_payload.author = message_author_1;
-
-        let key = format!("message{}", message_payload.index);
-        let context = json!({
-            "currentPage": "messages",
-            "title": "Messages",
-            key: message_payload.body,
-        });
-
-        let connection = establish_connection();
-        create_message(&connection, &message_payload);
-
-        Ok(HttpResponse::build(StatusCode::CREATED)
-            .content_type("application/json; charset=utf-8")
-            .json(context))
-    }
-}
-
-fn p404(data: web::Data<AppState>) -> Result<HttpResponse> {
-    let context = json!({
-        "currentPage": "404",
-        "title": "Not Found",
-    });
-    Ok(HttpResponse::build(StatusCode::NOT_FOUND)
-        .content_type("text/html; charset=utf-8")
-        .body(data.template_registry.render("404", &context).unwrap()))
-}
-
-#[get("/favicon.ico")]
-fn favicon() -> Result<fs::NamedFile> {
-    Ok(fs::NamedFile::open("static/favicon.ico")?)
-}
-
-#[get("/about")]
-fn about(data: web::Data<AppState>) -> Result<HttpResponse> {
-    let context = json!({
-        "currentPage": "about",
-        "title": "About",
-    });
-    Ok(HttpResponse::build(StatusCode::OK)
-        .content_type("text/html; charset=utf-8")
-        .body(data.template_registry.render("about", &context).unwrap()))
-}
-
-fn load_message_group(data: web::Data<AppState>, path: web::Path<String>) -> Result<HttpResponse> {
-    let message_group = format!("{}", path);
-    if !authorized(&message_group) {
-        p404(data)
-    } else {
-        let connection = establish_connection();
-        let new_messages = message_bodies_for_group(&connection, &message_group);
-
-        let button_text_1 = button_text(&new_messages[1]);
-        let input_disabled_1 = input_disabled(&new_messages[1]);
-        let button_text_3 = button_text(&new_messages[3]);
-        let input_disabled_3 = input_disabled(&new_messages[3]);
-        let guidance_1 = guidance(&new_messages[1]);
-        let guidance_3 = guidance(&new_messages[3]);
-
-        let context = json!({
-            "currentPage": "messages",
-            "title": "Messages",
-            "author0": "a0",
-            "author1": "a1",
-            "message0": paragraphs(&new_messages[0]),
-            "message1": &new_messages[1],
-            "inputDisabled1": input_disabled_1,
-            "buttonText1": button_text_1,
-            "guidance1": guidance_1,
-            "message2": paragraphs(&new_messages[2]),
-            "inputDisabled3": input_disabled_3,
-            "buttonText3": button_text_3,
-            "guidance3": guidance_3,
-            "message3": &new_messages[3],
-            "messageGroup": message_group,
-        });
-
-        Ok(HttpResponse::build(StatusCode::OK)
-            .content_type("text/html; charset=utf-8")
-            .body(data.template_registry.render("messages", &context).unwrap()))
-    }
-}
-
-fn paragraphs(body: &str) -> String {
-   body.split("\n").map(|paragraph| format!("<p>{}</p>", paragraph)).collect::<Vec<String>>().join("")
-}
-
-fn button_text(body: &str) -> &str {
-    if body.len() > 0 {
-        "Edit"
-    } else {
-        "Save"
-    }
-}
-
-fn input_disabled(body: &str) -> &str {
-    if body.len() > 0 {
-        "disabled"
-    } else {
-        ""
-    }
-}
-
-fn guidance(body: &str) -> &str {
-    if body.len() > 0 {
-        ""
-    } else {
-        "You will be able to edit after saving."
-    }
-}
-
-fn authorized(message_group: &str) -> bool {
-    let allowed_message_group = env::var("MESSAGE_GROUP_ID").unwrap();
-    message_group == allowed_message_group
-}
+use web_server::{self, AppState};
 
 fn main() -> io::Result<()> {
     dotenv().ok();
-    std::env::set_var("RUST_LOG", "actix_web=info,web=info");
+    env::set_var("RUST_LOG", "actix_web=info,web=info");
     env_logger::init();
 
     let mut listenfd = ListenFd::from_env();
@@ -175,16 +38,15 @@ fn main() -> io::Result<()> {
             // enable logger - always register actix-web Logger middleware last
             .wrap(middleware::Logger::default())
             .service(fs::Files::new("/static", "static").show_files_listing())
-            // register simple route, handle all methods
-            .service(about)
-            .service(favicon)
             .route("/", web::get().to(web_server::home))
-            .route("/messages/{message_group}", web::get().to(load_message_group))
-            .route("/messages/{message_group}", web::post().to(create_message_in_group))
+            .route("/favicon.ico", web::get().to(web_server::favicon))
+            .route("/about", web::get().to(web_server::about))
+            .route("/messages/{message_group}", web::get().to(web_server::load_message_group))
+            .route("/messages/{message_group}", web::post().to(web_server::create_message_in_group))
             .default_service(
                 // 404 for GET request
                 web::resource("")
-                    .route(web::get().to(p404))
+                    .route(web::get().to(web_server::p404))
                     // all requests that are not `GET`
                     .route(
                         web::route()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use actix_files as fs;
 use actix_web::{
     guard, middleware, web, App, HttpResponse, HttpServer
 };
@@ -35,7 +34,7 @@ fn main() -> io::Result<()> {
             .wrap(middleware::DefaultHeaders::new().header("Cache-Control", "max-age=0"))
             // enable logger - always register actix-web Logger middleware last
             .wrap(middleware::Logger::default())
-            .service(fs::Files::new("/static", "static").show_files_listing())
+            .service(web_server::static_files())
             .route("/", web::get().to(web_server::home))
             .route("/favicon.ico", web::get().to(web_server::favicon))
             .route("/about", web::get().to(web_server::about))

--- a/src/templates/registry.rs
+++ b/src/templates/registry.rs
@@ -1,0 +1,21 @@
+pub use handlebars::Handlebars;
+
+pub fn register_templates<'a>() -> Handlebars<'a> {
+    let mut template_registry = Handlebars::new();
+    template_registry.set_strict_mode(true);
+    let res =
+        template_registry.register_template_file("application", "./src/templates/partials/application.hbs")
+            .and_then(|_| { template_registry.register_template_file("header", "./src/templates/partials/header.hbs") })
+            .and_then(|_| { template_registry.register_template_file("home", "./src/templates/home.hbs") })
+            .and_then(|_| { template_registry.register_template_file("404", "./src/templates/404.hbs") })
+            .and_then(|_| { template_registry.register_template_file("messages", "./src/templates/messages.hbs") })
+            .and_then(|_| { template_registry.register_template_file("about", "./src/templates/about.hbs") });
+    match res {
+        Ok(_) => { },
+        Err(tfe) => {
+            panic!("Could not register template: {}", tfe)
+        }
+    }
+
+    template_registry
+}

--- a/src/templates/registry.rs
+++ b/src/templates/registry.rs
@@ -1,21 +1,39 @@
 pub use handlebars::Handlebars;
+use std::path::Path;
 
 pub fn register_templates<'a>() -> Handlebars<'a> {
     let mut template_registry = Handlebars::new();
     template_registry.set_strict_mode(true);
-    let res =
-        template_registry.register_template_file("application", "./src/templates/partials/application.hbs")
-            .and_then(|_| { template_registry.register_template_file("header", "./src/templates/partials/header.hbs") })
-            .and_then(|_| { template_registry.register_template_file("home", "./src/templates/home.hbs") })
-            .and_then(|_| { template_registry.register_template_file("404", "./src/templates/404.hbs") })
-            .and_then(|_| { template_registry.register_template_file("messages", "./src/templates/messages.hbs") })
-            .and_then(|_| { template_registry.register_template_file("about", "./src/templates/about.hbs") });
-    match res {
-        Ok(_) => { },
-        Err(tfe) => {
-            panic!("Could not register template: {}", tfe)
-        }
+
+    let partials_path = Path::new("./src/templates/partials/");
+    let templates_path = Path::new("./src/templates/");
+
+    for entry in partials_path.read_dir().expect(&format!("read_dir call failed for {:?}", partials_path)) {
+        register_template_dir_entry(& mut template_registry, entry);
+    }
+
+    for entry in templates_path.read_dir().expect(&format!("read_dir call failed for {:?}", templates_path)) {
+        register_template_dir_entry(& mut template_registry, entry);
     }
 
     template_registry
+}
+
+fn register_template_dir_entry(template_registry: &mut Handlebars, entry: Result<std::fs::DirEntry, std::io::Error>) {
+    if let Ok(entry) = entry {
+        let path = entry.path();
+        let ext = path.extension();
+        if let Some(ext) = ext {
+            if ext == "hbs" {
+                let name = path.file_stem().unwrap().to_str().unwrap();
+                let path_str = path.to_str().unwrap();
+                let res = template_registry.register_template_file(&name, &path_str);
+                if res.is_err() {
+                    panic!("Could not register template: {:?}", res)
+                }
+            }
+        }
+    } else {
+        panic!("Could not register template: {:?}", entry)
+    }
 }

--- a/tests/about_test.rs
+++ b/tests/about_test.rs
@@ -1,13 +1,12 @@
 use actix_web::dev::Service;
-use actix_web::{test, web, App};
+use actix_web::{test, App};
 use web_server;
 
 #[test]
 fn about_get() {
     let mut app = test::init_service(
         App::new()
-            .data(web_server::request_data())
-            .route("/about", web::get().to(web_server::about)));
+            .configure(web_server::config));
     let req = test::TestRequest::get().uri("/about").to_request();
     let resp = test::block_on(app.call(req)).unwrap();
 

--- a/tests/about_test.rs
+++ b/tests/about_test.rs
@@ -3,12 +3,12 @@ use actix_web::{test, web, App};
 use web_server;
 
 #[test]
-fn index_get() {
+fn about_get() {
     let mut app = test::init_service(
         App::new()
             .data(web_server::request_data())
-            .route("/", web::get().to(web_server::home)));
-    let req = test::TestRequest::get().uri("/").to_request();
+            .route("/about", web::get().to(web_server::about)));
+    let req = test::TestRequest::get().uri("/about").to_request();
     let resp = test::block_on(app.call(req)).unwrap();
 
     assert!(resp.status().is_success());

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,7 @@
+pub mod test_db;
+
+use dotenv::dotenv;
+
+pub fn load_env() {
+    dotenv().ok();
+}

--- a/tests/common/test_db.rs
+++ b/tests/common/test_db.rs
@@ -1,0 +1,10 @@
+use diesel::Connection;
+use diesel::pg::PgConnection;
+use std::env;
+
+pub fn establish_connection() -> PgConnection {
+    let database_url = env::var("DATABASE_URL_TEST")
+        .expect("DATABASE_URL_TEST must be set");
+    PgConnection::establish(&database_url)
+        .expect(&format!("Error connecting to {}", database_url))
+}

--- a/tests/db_messages_test.rs
+++ b/tests/db_messages_test.rs
@@ -1,0 +1,40 @@
+use diesel::prelude::*;
+use diesel::connection::Connection;
+use diesel::dsl::count_star;
+use web_server;
+use web_server::{models, schema::messages::dsl::*};
+
+mod common;
+
+use crate::common::{load_env, test_db};
+
+#[test]
+fn create_message() {
+    load_env();
+
+    let message_payload = web_server::MessagePayload {
+        message_group: String::from("mg1"),
+        index: 0,
+        body: String::from("body1"),
+        author: String::from("author1"),
+    };
+    let conn = test_db::establish_connection();
+
+    conn.test_transaction::<_, diesel::result::Error, _>(|| {
+        let message_count = messages.select(count_star()).get_result(&conn);
+        assert_eq!(Ok(0), message_count, "0 messages initially");
+
+        web_server::db::create_message(&conn, &message_payload);
+
+        let message_count = messages.select(count_star()).get_result(&conn);
+        assert_eq!(Ok(1), message_count, "1 message created");
+
+        let found_message = messages.first::<models::Message>(&conn).expect("Error loading messages");
+        assert_eq!(found_message.message_group, String::from("mg1"));
+        assert_eq!(found_message.index, 0);
+        assert_eq!(found_message.message_author, String::from("author1"));
+        assert_eq!(found_message.body, Some(String::from("body1")));
+
+        Ok(())
+    });
+}

--- a/tests/default_service_test.rs
+++ b/tests/default_service_test.rs
@@ -12,13 +12,13 @@ fn default_service() {
     let req = test::TestRequest::get().uri("/unknown").to_request();
     let resp = test::block_on(app.call(req)).unwrap();
 
-    assert!(resp.status().is_client_error());
-    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    assert!(resp.status().is_client_error(), "GET to unknown route returns 400-level error");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND, "GET to unknown route returns 404");
 
     let req = test::TestRequest::post().uri("/unknown").to_request();
     let resp = test::block_on(app.call(req)).unwrap();
 
-    assert!(resp.status().is_client_error());
-    assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+    assert!(resp.status().is_client_error(), "POST to unknown route returns 400-level error");
+    assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED, "POST to unknown route returns 405");
 }
 

--- a/tests/default_service_test.rs
+++ b/tests/default_service_test.rs
@@ -1,25 +1,14 @@
 use actix_web::dev::Service;
-use actix_web::{test, web, guard, http::StatusCode, App, HttpResponse};
+use actix_web::{test, http::StatusCode, App};
 use web_server;
 
 #[test]
 fn default_service() {
     let mut app = test::init_service(
         App::new()
-            .data(web_server::request_data())
-            .default_service(
-                // 404 for GET request
-                web::resource("")
-                    .route(web::get().to(web_server::p404))
-                    // all requests that are not `GET`
-                    .route(
-                        web::route()
-                            .guard(guard::Not(guard::Get()))
-                            .to(HttpResponse::MethodNotAllowed),
-                    ),
-            )
+            .configure(web_server::config)
+            .default_service(web_server::default_service()));
 
-    );
     let req = test::TestRequest::get().uri("/unknown").to_request();
     let resp = test::block_on(app.call(req)).unwrap();
 

--- a/tests/default_service_test.rs
+++ b/tests/default_service_test.rs
@@ -1,0 +1,37 @@
+use actix_web::dev::Service;
+use actix_web::{test, web, guard, App, HttpResponse};
+use actix_web::http::{StatusCode};
+
+use web_server;
+
+#[test]
+fn default_service() {
+    let mut app = test::init_service(
+        App::new()
+            .data(web_server::request_data())
+            .default_service(
+                // 404 for GET request
+                web::resource("")
+                    .route(web::get().to(web_server::p404))
+                    // all requests that are not `GET`
+                    .route(
+                        web::route()
+                            .guard(guard::Not(guard::Get()))
+                            .to(HttpResponse::MethodNotAllowed),
+                    ),
+            )
+
+    );
+    let req = test::TestRequest::get().uri("/unknown").to_request();
+    let resp = test::block_on(app.call(req)).unwrap();
+
+    assert!(resp.status().is_client_error());
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+    let req = test::TestRequest::post().uri("/unknown").to_request();
+    let resp = test::block_on(app.call(req)).unwrap();
+
+    assert!(resp.status().is_client_error());
+    assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+}
+

--- a/tests/default_service_test.rs
+++ b/tests/default_service_test.rs
@@ -1,7 +1,5 @@
 use actix_web::dev::Service;
-use actix_web::{test, web, guard, App, HttpResponse};
-use actix_web::http::{StatusCode};
-
+use actix_web::{test, web, guard, http::StatusCode, App, HttpResponse};
 use web_server;
 
 #[test]

--- a/tests/home_test.rs
+++ b/tests/home_test.rs
@@ -1,13 +1,13 @@
 use actix_web::dev::Service;
-use actix_web::{test, web, App};
+use actix_web::{test, App};
 use web_server;
 
 #[test]
 fn index_get() {
     let mut app = test::init_service(
         App::new()
-            .data(web_server::request_data())
-            .route("/", web::get().to(web_server::home)));
+            .configure(web_server::config));
+
     let req = test::TestRequest::get().uri("/").to_request();
     let resp = test::block_on(app.call(req)).unwrap();
 

--- a/tests/home_test.rs
+++ b/tests/home_test.rs
@@ -1,0 +1,18 @@
+use actix_web::dev::Service;
+use actix_web::{test, web, App};
+use web_server;
+
+#[test]
+fn index_get() {
+    let mut app = test::init_service(
+        App::new()
+            .data(web_server::AppState {
+                template_registry: web_server::register_templates(),
+            })
+            .route("/", web::get().to(web_server::home)));
+    let req = test::TestRequest::get().uri("/").to_request();
+    let resp = test::block_on(app.call(req)).unwrap();
+
+    assert!(resp.status().is_success());
+}
+

--- a/tests/static_files_test.rs
+++ b/tests/static_files_test.rs
@@ -1,0 +1,24 @@
+use actix_web::dev::Service;
+use actix_web::{test, App, http::StatusCode};
+use web_server;
+
+#[test]
+fn static_get() {
+    let mut app = test::init_service(
+        App::new()
+            .service(web_server::static_files()));
+
+    let req = test::TestRequest::get().uri("/static/404.html").to_request();
+    let resp = test::block_on(app.call(req)).unwrap();
+    assert!(resp.status().is_success());
+
+    let req = test::TestRequest::get().uri("/static/favicon.ico").to_request();
+    let resp = test::block_on(app.call(req)).unwrap();
+    assert!(resp.status().is_success());
+
+    let req = test::TestRequest::get().uri("/static/unknown.jpg").to_request();
+    let resp = test::block_on(app.call(req)).unwrap();
+    assert!(resp.status().is_client_error());
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+

--- a/tests/static_files_test.rs
+++ b/tests/static_files_test.rs
@@ -10,15 +10,15 @@ fn static_get() {
 
     let req = test::TestRequest::get().uri("/static/404.html").to_request();
     let resp = test::block_on(app.call(req)).unwrap();
-    assert!(resp.status().is_success());
+    assert!(resp.status().is_success(), "Successfully serves static 404 page");
 
     let req = test::TestRequest::get().uri("/static/favicon.ico").to_request();
     let resp = test::block_on(app.call(req)).unwrap();
-    assert!(resp.status().is_success());
+    assert!(resp.status().is_success(), "Successfully serves favicon");
 
     let req = test::TestRequest::get().uri("/static/unknown.jpg").to_request();
     let resp = test::block_on(app.call(req)).unwrap();
-    assert!(resp.status().is_client_error());
-    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    assert!(resp.status().is_client_error(), "Returns 400-level error for unknown static file");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND, "Returns 404 for unknown static file");
 }
 

--- a/tests/static_files_test.rs
+++ b/tests/static_files_test.rs
@@ -6,7 +6,7 @@ use web_server;
 fn static_get() {
     let mut app = test::init_service(
         App::new()
-            .service(web_server::static_files()));
+            .configure(web_server::config));
 
     let req = test::TestRequest::get().uri("/static/404.html").to_request();
     let resp = test::block_on(app.call(req)).unwrap();


### PR DESCRIPTION
* Extract `src/lib.rs` from `src/main.rs`, following standard Cargo pattern for binary applications.
* To support referencing lib, rename package from `web` to `web-server` to avoid conflict with `actix_web::web`.
* Separate out handlebars template registry module, which now registers all `.hbs` files in the `src/templates` directory.
* Define integration tests for existing web handlers, and one test of DB interaction.